### PR TITLE
2.0.5 fixes

### DIFF
--- a/CIARE/GUI/DarkModeMain.cs
+++ b/CIARE/GUI/DarkModeMain.cs
@@ -1,3 +1,4 @@
+using CIARE.Utils;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.Versioning;
@@ -34,7 +35,13 @@ namespace CIARE.GUI
             form.BackColor = (isVsTheme)? Color.FromArgb(51, 51, 51): Color.FromArgb(0, 1, 10);
             form.ForeColor = Color.FromArgb(192, 215, 207);
             richTextBox.BackColor = (isVsTheme) ? Color.FromArgb(30, 30, 30) : Color.FromArgb(2, 0, 10);
-            richTextBox.ForeColor = Color.FromArgb(192, 215, 207);
+            if (GlobalVariables.isRed)
+            {
+                richTextBox.ForeColor = Color.Red;
+                GlobalVariables.isRed = false;
+            }
+            else
+                richTextBox.ForeColor = Color.FromArgb(192, 215, 207);
             groupBox.ForeColor = Color.FromArgb(192, 215, 207);
             separator2.ForeColor = Color.FromArgb(192, 215, 207);
             separator3.ForeColor = Color.FromArgb(192, 215, 207);

--- a/CIARE/Model/HotKeys.resx
+++ b/CIARE/Model/HotKeys.resx
@@ -127,7 +127,7 @@ CTRL + T         : Load C# Main template.
 
 ------------ Editor management ------------
 CTRL + Z         : Undo last modifications.
-CTRL + R         : Redo last modifications.
+CTRL + Y         : Redo last modifications.
 CTRL + Delete    : Delete words to right.
 CTRL + Backspace : Delete words to left.
 CTRL + D         : Delete current line.

--- a/CIARE/Model/MainForm.Designer.cs
+++ b/CIARE/Model/MainForm.Designer.cs
@@ -491,6 +491,7 @@ namespace CIARE
             EditorTabControl.HandleCreated += EditorTabControl_HandleCreated;
             EditorTabControl.MouseClick += EditorTabControl_MouseClick;
             EditorTabControl.MouseDown += EditorTabControl_MouseDown;
+            EditorTabControl.KeyDown += EditorTabControl_KeyDown;
             // 
             // tabPage1
             // 

--- a/CIARE/Model/MainForm.cs
+++ b/CIARE/Model/MainForm.cs
@@ -265,11 +265,10 @@ namespace CIARE
             var path = EditorTabControl.SelectedTab.ToolTipText;
             if (File.Exists(path))
             {
-                var fileInfo = File.ReadAllText(path,Encoding.UTF8);
                 var sizeTxt = Encoding.UTF8.GetByteCount(SelectedEditor.GetSelectedEditor().Text);
-
+                
                 //Remove * depende of file size in comparison text size.
-                if (fileInfo.Length != sizeTxt)
+                if (GlobalVariables.openedFileSize != sizeTxt)
                 {
                     this.Text = $"*{GlobalVariables.openedFileName.Trim()} : {FileManage.GetFilePath(GlobalVariables.openedFilePath)} - CIARE {versionName}";
                     string curentTabTitle = EditorTabControl.SelectedTab.Text.Replace("*", string.Empty);
@@ -886,6 +885,11 @@ namespace CIARE
                 GlobalVariables.openedFilePath = filePath;
                 var fileInfo = new FileInfo(GlobalVariables.openedFilePath);
                 GlobalVariables.openedFileName = fileInfo.Name;
+                if (File.Exists(filePath))
+                {
+                    var readData = File.ReadAllText(filePath, Encoding.UTF8);
+                    GlobalVariables.openedFileSize = readData.Length;
+                }
             }
             if (!titleTab.Contains("New Pag") && !titleTab.Contains("+"))
             {

--- a/CIARE/Model/MainForm.cs
+++ b/CIARE/Model/MainForm.cs
@@ -368,6 +368,12 @@ namespace CIARE
                 case Keys.Right | Keys.Control:
                     TabControllerManage.SwitchTabs(ref EditorTabControl, false);
                     return true;
+                case Keys.Left | Keys.Shift:
+                    TabControllerManage.SwitchTabs(ref EditorTabControl, true);
+                    return true;
+                case Keys.Right | Keys.Shift:
+                    TabControllerManage.SwitchTabs(ref EditorTabControl, false);
+                    return true;
                 case Keys.Tab | Keys.Control:
                     worker = new BackgroundWorker();
                     worker.DoWork += NewHotKeyTab;
@@ -1063,10 +1069,29 @@ namespace CIARE
         {
             TabControllerManage.CloseAllTabs(EditorTabControl, SelectedEditor.GetSelectedEditor());
         }
+
+        /// <summary>
+        /// Close all tabs but not selected one.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void closeAllTabsOne_Click(object sender, EventArgs e)
         {
             int index = EditorTabControl.SelectedIndex;
             TabControllerManage.CloseAllTabsOne(EditorTabControl, SelectedEditor.GetSelectedEditor(), index);
+        }
+
+        /// <summary>
+        /// Cancel left/right key scroll.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void EditorTabControl_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Left || e.KeyCode == Keys.Right)
+            {
+                e.Handled = true;
+            }
         }
     }
 }

--- a/CIARE/Model/MainForm.cs
+++ b/CIARE/Model/MainForm.cs
@@ -293,6 +293,8 @@ namespace CIARE
         /// <param name="e"></param>
         private void NewHotKeyTab(object sender, DoWorkEventArgs e)
         {
+            if (outputRBT.ForeColor == Color.Red)
+                GlobalVariables.isRed = true;
             TabControllerManage.AddNewTab(EditorTabControl);
         }
 

--- a/CIARE/Model/MainForm.cs
+++ b/CIARE/Model/MainForm.cs
@@ -39,6 +39,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Drawing;
 using System.ComponentModel;
+using System.Text;
 
 
 namespace CIARE
@@ -261,13 +262,27 @@ namespace CIARE
         /// <param name="e"></param>
         private void textEditorControl1_TextChanged(object sender, EventArgs e)
         {
-            string titleTab = EditorTabControl.SelectedTab.Text;
-            if (GlobalVariables.openedFilePath.Length > 0 && !titleTab.Contains("New Page"))
+            var path = EditorTabControl.SelectedTab.ToolTipText;
+            if (File.Exists(path))
             {
-                this.Text = $"*{GlobalVariables.openedFileName.Trim()} : {FileManage.GetFilePath(GlobalVariables.openedFilePath)} - CIARE {versionName}";
-                string curentTabTitle = EditorTabControl.SelectedTab.Text.Replace("*", string.Empty);
-                EditorTabControl.SelectedTab.Text = $"*{curentTabTitle}";
+                var fileInfo = File.ReadAllText(path,Encoding.UTF8);
+                var sizeTxt = Encoding.UTF8.GetByteCount(SelectedEditor.GetSelectedEditor().Text);
+
+                //Remove * depende of file size in comparison text size.
+                if (fileInfo.Length != sizeTxt)
+                {
+                    this.Text = $"*{GlobalVariables.openedFileName.Trim()} : {FileManage.GetFilePath(GlobalVariables.openedFilePath)} - CIARE {versionName}";
+                    string curentTabTitle = EditorTabControl.SelectedTab.Text.Replace("*", string.Empty);
+                    EditorTabControl.SelectedTab.Text = $"*{curentTabTitle}";
+                }
+                else
+                {
+                    this.Text = $"{GlobalVariables.openedFileName.Trim()} : {FileManage.GetFilePath(GlobalVariables.openedFilePath)} - CIARE {versionName}";
+                    string curentTabTitle = EditorTabControl.SelectedTab.Text.Replace("*", string.Empty);
+                    EditorTabControl.SelectedTab.Text = $"{curentTabTitle}";
+                }
             }
+
             LinesManage.GetTotalLinesCount(linesCountLbl);
             SelectedEditor.GetSelectedEditor().Document.FoldingManager.FoldingStrategy = new FoldingStrategy();
             SelectedEditor.GetSelectedEditor().Document.FoldingManager.UpdateFoldings(null, null);
@@ -875,6 +890,7 @@ namespace CIARE
             if (!titleTab.Contains("New Pag") && !titleTab.Contains("+"))
             {
                 this.Text = $"{titleTab.Trim()} : {FileManage.GetFilePath(GlobalVariables.openedFilePath)} - CIARE {versionName}";
+
             }
             else
             {
@@ -984,7 +1000,7 @@ namespace CIARE
             TabControllerManage.DrawTabControl(EditorTabControl, e);
 
             // Set transparent header bar.
-            if(GlobalVariables.isVStheme)
+            if (GlobalVariables.isVStheme)
                 TabControllerManage.SetTransparentTabBar(EditorTabControl, e, 51, 51, 51);
             else
                 TabControllerManage.SetTransparentTabBar(EditorTabControl, e, 0, 1, 10);
@@ -993,6 +1009,8 @@ namespace CIARE
             if (GlobalVariables.apiConnected || GlobalVariables.apiRemoteConnected)
                 TabControllerManage.ColorTab(EditorTabControl, GlobalVariables.liveTabIndex, e, Color.Red);
             var taBindex = EditorTabControl.SelectedIndex;
+
+            // Color light green if editor data is unsaved.
             TabControllerManage.ColorTab(EditorTabControl, taBindex, e, Color.LightGray);
         }
 

--- a/CIARE/Model/MainForm.cs
+++ b/CIARE/Model/MainForm.cs
@@ -336,6 +336,12 @@ namespace CIARE
         {
             switch (keyData)
             {
+                case Keys.PageDown | Keys.Control:
+                    TabControllerManage.SwitchTabs(ref EditorTabControl, true);
+                    return true;
+                case Keys.PageUp | Keys.Control:
+                    TabControllerManage.SwitchTabs(ref EditorTabControl, false);
+                    return true;
                 case Keys.Q | Keys.Control:
                     LiveShareHost liveShareHost = new LiveShareHost();
                     liveShareHost.ShowDialog();

--- a/CIARE/Properties/AssemblyInfo.cs
+++ b/CIARE/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.4.0")]
-[assembly: AssemblyFileVersion("2.0.4.0")]
+[assembly: AssemblyVersion("2.0.5.0")]
+[assembly: AssemblyFileVersion("2.0.5.0")]

--- a/CIARE/Utils/FileManage.cs
+++ b/CIARE/Utils/FileManage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
+using System.Text;
 using System.Windows.Forms;
 using CIARE.GUI;
 using CIARE.Reference;
@@ -99,6 +100,8 @@ MessageBoxIcon.Warning);
                         FileInfo fileInfo = new FileInfo(GlobalVariables.openedFilePath);
                         GlobalVariables.openedFileName = fileInfo.Name;
                         GlobalVariables.savedFile = true;
+                        var readData = File.ReadAllText(fileInfo.FullName, Encoding.UTF8);
+                        GlobalVariables.openedFileSize = readData.Length;
                     }
                 }
                 catch (Exception e)
@@ -361,6 +364,8 @@ MessageBoxIcon.Warning);
                     MainForm.Instance.EditorTabControl.SelectedTab.ToolTipText = GlobalVariables.openedFilePath;
                     MainForm.Instance.Text = $"{GlobalVariables.openedFileName} : {GetFilePath(GlobalVariables.openedFilePath)} - CIARE {MainForm.Instance.versionName}";
                     StoreTabs(GlobalVariables.openedFilePath);
+                    var readData = File.ReadAllText(fileInfo.FullName, Encoding.UTF8);
+                    GlobalVariables.openedFileSize = readData.Length;
                     return;
                 }
                 SaveFile(SelectedEditor.GetSelectedEditor().Text);

--- a/CIARE/Utils/GlobalVariables.cs
+++ b/CIARE/Utils/GlobalVariables.cs
@@ -46,6 +46,8 @@ namespace CIARE.Utils
         public static bool OUnsafeCode = false;
         public static bool compileTime = false;
         public static bool codeWriter = false;
+        public static bool isRed = false;
+
         public static string Framework { get; set; } = "net6.0-windows";
         public static bool noClear { get; set; } = false;
         public static string binaryName = string.Empty;

--- a/CIARE/Utils/GlobalVariables.cs
+++ b/CIARE/Utils/GlobalVariables.cs
@@ -20,6 +20,7 @@ namespace CIARE.Utils
         public static bool isStoringTabs = false;
         public static string openedFilePath { get; set; } = string.Empty;
         public static string openedFileName = string.Empty;
+        public static int openedFileSize = 0;
         public static int openedFileLen = 0;
         public static string commandLineArguments = string.Empty;
         public static string findData = string.Empty;

--- a/CIARE/Utils/GlobalVariables.cs
+++ b/CIARE/Utils/GlobalVariables.cs
@@ -18,8 +18,9 @@ namespace CIARE.Utils
         public static readonly string tabsFilePathAll = $"{userProfileDirectory}tabsFilePathAll.cDat";
         public static string processArg = string.Empty;
         public static bool isStoringTabs = false;
-        public static string openedFilePath = string.Empty;
+        public static string openedFilePath { get; set; } = string.Empty;
         public static string openedFileName = string.Empty;
+        public static int openedFileLen = 0;
         public static string commandLineArguments = string.Empty;
         public static string findData = string.Empty;
         public static string findWhat = string.Empty;

--- a/ICSharpCode.TextEditor/Resources/CSharp-Mode-Dark.xshd
+++ b/ICSharpCode.TextEditor/Resources/CSharp-Mode-Dark.xshd
@@ -1697,6 +1697,7 @@
 				<Key word="LinkLabel" />
 				<Key word="LinkLabelLinkClickedEventArgs" />
 				<Key word="LinkLabelLinkClickedEventHandler" />
+        <Key word="List" />
 				<Key word="ListBindableAttribute" />
 				<Key word="ListBindingConverter" />
 				<Key word="ListBindingHelper" />

--- a/ICSharpCode.TextEditor/Resources/CSharp-Mode-DarkVS.xshd
+++ b/ICSharpCode.TextEditor/Resources/CSharp-Mode-DarkVS.xshd
@@ -1691,6 +1691,7 @@
         <Key word="LinkLabel" />
         <Key word="LinkLabelLinkClickedEventArgs" />
         <Key word="LinkLabelLinkClickedEventHandler" />
+        <Key word="List" />
         <Key word="ListBindableAttribute" />
         <Key word="ListBindingConverter" />
         <Key word="ListBindingHelper" />

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ CTRL + T         : Load C# Main template.
 
 ------------ Editor management ------------
 CTRL + Z         : Undo last modifications.
-CTRL + R         : Redo last modifications.
+CTRL + Y         : Redo last modifications.
 CTRL + Delete    : Delete words to right.
 CTRL + Backspace : Delete words to left.
 CTRL + D         : Delete current line.


### PR DESCRIPTION
* Added option to remove * on modified text when is set back to last saved state. Works on Redo/Undo as well.
* Fixed typo on hotkeys menu for CTRL + Y.
* Fixed tab navigation for shift + left/right keys and ctrl + page down/up keys.
* Remove tab navigation for left/right key,